### PR TITLE
0.1.3 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Steps:
 
 
 ```bash
-sudo guacamole-compose --init
+guacamole-compose --init
 vi parameters.yaml
 sudo guacamole-compose --deploy --ldap
 
@@ -112,15 +112,6 @@ sudo chown user:user shared
 ```
 
 
-## Updating groups and connections from ldap
-
-After changes are made to user groups or computers within the ldap server, you can run the following command to automatically update guacamole user group permissions and connections. You do not need to redeploy. 
-
-```bash
-sudo guacamole-compose --ldap
-```
-
-
 ## Cleanup of shared directory
 
 The template parameters.yaml uses a common folder called 'shared' for transferring files in and out of the remote computers. To prevent this folder from growing too large, you can periodically remove files older than ~6 days with a cron job. This example is shown below.
@@ -138,3 +129,21 @@ sudo rm -r dist
 python3.9 setup.py bdist_wheel --universal
 twine upload dist/*
 ```
+
+## Changelog
+
+### 0.1.3
+#### Fixed
+- create the ./shared folder with the --init command (without sudo). This fixes a permission issue where users would have to `sudo chown user:user ./shared` for file transfers.
+- Updated README.md to remove `sudo` from in front of `guacamole-compose --init`
+- Updated the internal proxies from 127.0.0.1 to the default. (as the rwp container will not be 127.0.0.1 to the guacamole container.) This is safe as the guacamole container does not have any exposed ports.
+
+### 0.1.2
+#### Added
+- server.xml so that the guacamole webpage correctly shows the remote address via X-Forwarded-For.
+- `option forwardfor` in the haproxy templates.
+- code in the init section to create the server.xml file from the template in ./tomcat folder.
+  
+#### Fixed
+- Updated nginx init conf with max body size of 10000 (for large file transfers.) Nginx configuration option already had this set.
+- Duplicate documentation section in README.md on updating groups and connections.

--- a/guacamole_compose/cli.py
+++ b/guacamole_compose/cli.py
@@ -66,12 +66,15 @@ def main():
                        './nginx/certs',
                        './nginx/auth',
                        './haproxy',
-                       './haproxy/certs']:
+                       './haproxy/certs',
+                       './tomcat',
+                       './shared']:
             if not os.path.exists(folder):
                 os.makedirs(folder)
         shutil.copy(os.path.join(pkgdir, 'templates/parameters.yaml'), os.getcwd())
         shutil.copy(os.path.join(pkgdir, 'templates/nginx_init.conf'), './nginx/conf/nginx.conf')
         shutil.copy(os.path.join(pkgdir, 'templates/haproxy_init.cfg'), './haproxy/haproxy.cfg')
+        shutil.copy(os.path.join(pkgdir, 'templates/server.xml'), './tomcat/server.xml')
     else:
         params = yaml.load(open('parameters.yaml', 'r'), Loader=yaml.FullLoader)
         client = docker.from_env()

--- a/guacamole_compose/templates/docker-compose.yml.haproxy.template
+++ b/guacamole_compose/templates/docker-compose.yml.haproxy.template
@@ -50,6 +50,7 @@ services:
     restart: always
     volumes:
       - ./guacamole_home:/guacamole_home:ro
+      - ./tomcat/server.xml:/usr/local/tomcat/conf/server.xml:ro
   haproxy:
     container_name: haproxy
     depends_on:

--- a/guacamole_compose/templates/docker-compose.yml.template
+++ b/guacamole_compose/templates/docker-compose.yml.template
@@ -50,6 +50,7 @@ services:
     restart: always
     volumes:
       - ./guacamole_home:/guacamole_home:ro
+      - ./tomcat/server.xml:/usr/local/tomcat/conf/server.xml:ro
   nginx:
    container_name: nginx
    depends_on:

--- a/guacamole_compose/templates/haproxy.template
+++ b/guacamole_compose/templates/haproxy.template
@@ -22,6 +22,7 @@ frontend http
 
 frontend https
     bind *:443 ssl crt /usr/local/etc/certs/
+    option forwardfor
     http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;"
     acl is_root path /
     http-request redirect  code 301  location http://%[hdr(host)]/guacamole if is_root

--- a/guacamole_compose/templates/haproxy_init.cfg
+++ b/guacamole_compose/templates/haproxy_init.cfg
@@ -18,6 +18,7 @@ frontend http
     # Redirect to https
     bind *:80
     mode http
+    option forwardfor
     use_backend guacamole
     acl is_root path /
     http-request redirect  code 301  location http://%[hdr(host)]/guacamole if is_root

--- a/guacamole_compose/templates/nginx_init.conf
+++ b/guacamole_compose/templates/nginx_init.conf
@@ -16,7 +16,7 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $http_connection;
             proxy_cookie_path /guacamole/ /guacamole/;
-            client_max_body_size 1000m;
+            client_max_body_size 10000m;
             access_log off;
         }
     }

--- a/guacamole_compose/templates/server.xml
+++ b/guacamole_compose/templates/server.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector protocol="AJP/1.3"
+               address="::1"
+               port="8009"
+               redirectPort="8443" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}| 169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}| 0:0:0:0:0:0:0:1|::1"
+               remoteIpHeader="x-forwarded-for"
+               remoteIpProxiesHeader="x-forwarded-by"
+               protocolHeader="x-forwarded-proto" />
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="guacamole-compose",
-    version="0.1.1",
+    version="0.1.3",
     author="John Burt",
     author_email="johnburt.jab@gmail.com",
     description="Easy deployment of Apache Guacamole.",


### PR DESCRIPTION
### 0.1.3
#### Fixed
- create the ./shared folder with the --init command (without sudo). This fixes a permission issue where users would have to `sudo chown user:user ./shared` for file transfers.
- Updated README.md to remove `sudo` from in front of `guacamole-compose --init`
- Updated the internal proxies from 127.0.0.1 to the default. (as the rwp container will not be 127.0.0.1 to the guacamole container.) This is safe as the guacamole container does not have any exposed ports.

### 0.1.2
#### Added
- server.xml so that the guacamole webpage correctly shows the remote address via X-Forwarded-For.
- `option forwardfor` in the haproxy templates.
- code in the init section to create the server.xml file from the template in ./tomcat folder.

#### Fixed
- Updated nginx init conf with max body size of 10000 (for large file transfers.) Nginx configuration option already had this set.
- Duplicate documentation section in README.md on updating groups and connections.