### PR TITLE
0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ twine upload dist/*
 
 ## Changelog
 
+### 0.1.4
+#### Fixed
+- internalProxies in server.xml to be more generic and work no matter the internal rwp address.
+- Added checks for `guacamole-compose --init` to not overwrite existing files.
+
 ### 0.1.3
 #### Fixed
 - create the ./shared folder with the --init command (without sudo). This fixes a permission issue where users would have to `sudo chown user:user ./shared` for file transfers.

--- a/guacamole_compose/cli.py
+++ b/guacamole_compose/cli.py
@@ -71,10 +71,13 @@ def main():
                        './shared']:
             if not os.path.exists(folder):
                 os.makedirs(folder)
-        shutil.copy(os.path.join(pkgdir, 'templates/parameters.yaml'), os.getcwd())
-        shutil.copy(os.path.join(pkgdir, 'templates/nginx_init.conf'), './nginx/conf/nginx.conf')
-        shutil.copy(os.path.join(pkgdir, 'templates/haproxy_init.cfg'), './haproxy/haproxy.cfg')
-        shutil.copy(os.path.join(pkgdir, 'templates/server.xml'), './tomcat/server.xml')
+        pkgfiles = {'parameters.yaml': './parameters.yaml',
+                    'nginx_init.conf': './nginx/conf/nginx.conf',
+                    'haproxy_init.cfg': './haproxy/haproxy.cfg',
+                    'server.xml': './tomcat/server.xml'}
+        for pkgfile, dstfile in pkgfiles.items():
+            if not os.path.isfile(dstfile):
+                shutil.copy(os.path.join(pkgdir, 'templates/' + pkgfile), dstfile)
     else:
         params = yaml.load(open('parameters.yaml', 'r'), Loader=yaml.FullLoader)
         client = docker.from_env()

--- a/guacamole_compose/templates/server.xml
+++ b/guacamole_compose/templates/server.xml
@@ -165,7 +165,7 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
-               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}| 169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}| 0:0:0:0:0:0:0:1|::1"
+               internalProxies=".*"
                remoteIpHeader="x-forwarded-for"
                remoteIpProxiesHeader="x-forwarded-by"
                protocolHeader="x-forwarded-proto" />

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="guacamole-compose",
-    version="0.1.3",
+    version="0.1.4",
     author="John Burt",
     author_email="johnburt.jab@gmail.com",
     description="Easy deployment of Apache Guacamole.",


### PR DESCRIPTION
### 0.1.4
#### Fixed
- internalProxies in server.xml to be more generic and work no matter the internal rwp address.
- Added checks for `guacamole-compose --init` to not overwrite existing files.